### PR TITLE
Setting GH Action terraform-static-analysis@15.0.0

### DIFF
--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - "*"
-  
+
 permissions:
   id-token: write
   contents: read
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@main
+        uses: ministryofjustice/github-actions/terraform-static-analysis@15.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Pins action version to known working relase tag.
Will avoid experiencing any bugs that may get pushed to the main branch.