### PR TITLE
Add 'tfenv use 1.1.7' step to local run instructions

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -77,5 +77,5 @@ jobs:
     - name: Manual instructions
       run: |
         echo "Until permission on this repository are resolved Terraform Apply needs to be run locally."
-        echo "Now run the main branch locally to apply changes\n tfenv use 1.1.7 \n make init \n make apply"
+        echo "Now run the main branch locally to apply changes\n make init \n make apply"
 

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -77,6 +77,5 @@ jobs:
     - name: Manual instructions
       run: |
         echo "Until permission on this repository are resolved Terraform Apply needs to be run locally."
-        echo "Now run the main branch locally to apply changes\n make init\n make apply"
+        echo "Now run the main branch locally to apply changes\n tfenv use 1.1.7 \n make init \n make apply"
 
-  

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -77,5 +77,5 @@ jobs:
     - name: Manual instructions
       run: |
         echo "Until permission on this repository are resolved Terraform Apply needs to be run locally."
-        echo "Now run the main branch locally to apply changes\n make init \n make apply"
+        echo "Now run the main branch locally to apply changes\n tfenv use 1.1.7 \n make init \n make apply"
 

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -74,8 +74,10 @@ jobs:
     #   run: terraform apply -auto-approve
 
     # Instructions
+    # Note : It is recommended to lock Terraform version to https://github.com/ministryofjustice/mojo-aws-github-oidc-provider/blob/442480963302fb987646203be7464711377c0421/versions.tf
+    # to enforce the use of a specific version across local and CI environments
     - name: Manual instructions
       run: |
         echo "Until permission on this repository are resolved Terraform Apply needs to be run locally."
-        echo "Now run the main branch locally to apply changes\n tfenv use 1.1.7 \n make init \n make apply"
+        echo "Now run the main branch locally to apply changes \n make init \n make apply"
 

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ export MYGITHUBTOKEN="ghp_96ac5bba9c9f054d6451ae50b55996b6"
 6. Add the token in the `.env` file or add to `~/.bash_aliases` like as shown above
 7. Make sure the `AWS_PROFILE` values matches the AWS Cli profile name for the MoJO Shared Services AWS account on your workstation. It is recommended that you use [MoJ Cloud Operations Team - Best practices guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#configure-aws-vault) to configure your AWS-Vault with AWS SSO.
 8. Make sure correct repositories are added in the `github_repositories` in the `locals.tf` file.
-9. Switch your current Terraform CLI to use version 1.1.7 if running locally.
+9. Run tfenv use 1.1.7 to set the version locally.
 10. Run `make apply` to apply terraform. See `Makefile` for more targets.

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ export MYGITHUBTOKEN="ghp_96ac5bba9c9f054d6451ae50b55996b6"
 6. Add the token in the `.env` file or add to `~/.bash_aliases` like as shown above
 7. Make sure the `AWS_PROFILE` values matches the AWS Cli profile name for the MoJO Shared Services AWS account on your workstation. It is recommended that you use [MoJ Cloud Operations Team - Best practices guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#configure-aws-vault) to configure your AWS-Vault with AWS SSO.
 8. Make sure correct repositories are added in the `github_repositories` in the `locals.tf` file.
-9. Run tfenv use 1.1.7 to set the version locally.
+9. Switch your current Terraform CLI to use version 1.1.7 if running locally.
 10. Run `make apply` to apply terraform. See `Makefile` for more targets.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ export MYGITHUBTOKEN="ghp_96ac5bba9c9f054d6451ae50b55996b6"
 ## How to use this
 
 1. Clone this repository in a directory on your developers workstation.
-1. Change your working directory to the newly created directory `aws-github-oidc-provider`.
-1. Copy the example env file `cp .env.example .env`
-1. Create a GitHub personal access token. Please use this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) if you need help.
-1. Add the token in the `.env` file or add to `~/.bash_aliases` like as shown above
-1. Make sure the `AWS_PROFILE` values matches the AWS Cli profile name for the MoJO Shared Services AWS account on your workstation. It is recommended that you use [MoJ Cloud Operations Team - Best practices guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#configure-aws-vault) to configure your AWS-Vault with AWS SSO.
-1. Make sure correct repositories are added in the `github_repositories` in the `locals.tf` file.
-1. Run `make apply` to apply terraform. See `Makefile` for more targets.
+2. Change your working directory to the newly created directory `aws-github-oidc-provider`.
+3. Copy the example env file `cp .env.example .env`
+4. Create a GitHub personal access token. Please use this [guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) if you need help.
+6. Add the token in the `.env` file or add to `~/.bash_aliases` like as shown above
+7. Make sure the `AWS_PROFILE` values matches the AWS Cli profile name for the MoJO Shared Services AWS account on your workstation. It is recommended that you use [MoJ Cloud Operations Team - Best practices guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#configure-aws-vault) to configure your AWS-Vault with AWS SSO.
+8. Make sure correct repositories are added in the `github_repositories` in the `locals.tf` file.
+9. Run tfenv use 1.1.7 to set the version locally.
+10. Run `make apply` to apply terraform. See `Makefile` for more targets.

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ export MYGITHUBTOKEN="ghp_96ac5bba9c9f054d6451ae50b55996b6"
 6. Add the token in the `.env` file or add to `~/.bash_aliases` like as shown above
 7. Make sure the `AWS_PROFILE` values matches the AWS Cli profile name for the MoJO Shared Services AWS account on your workstation. It is recommended that you use [MoJ Cloud Operations Team - Best practices guide](https://ministryofjustice.github.io/cloud-operations/documentation/team-guide/best-practices/use-aws-sso.html#configure-aws-vault) to configure your AWS-Vault with AWS SSO.
 8. Make sure correct repositories are added in the `github_repositories` in the `locals.tf` file.
-9. Run tfenv use 1.1.7 to set the version locally.
+9. Lock Terraform version. Please use the version in https://github.com/ministryofjustice/mojo-aws-github-oidc-provider/blob/442480963302fb987646203be7464711377c0421/versions.tf
 10. Run `make apply` to apply terraform. See `Makefile` for more targets.

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 1.1.7"
+  required_version = ">= 1.1.7"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = "= 1.1.7"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Updated the local execution steps to explicitly set the Terraform version using tfenv. This ensures consistency with the required version before running 'make init' and 'make apply'